### PR TITLE
Post lacked cover photo definition

### DIFF
--- a/posts/1.post.toml
+++ b/posts/1.post.toml
@@ -35,3 +35,7 @@ How can I contribute?
 As of this writing, Purlin press is not yet ready to accept submissions for other work. I want to refrain from taking too much on at once until I can prove to myself that I can actually do this whole process. If you still wish to drop a note or idea or feedback to us, feel free to send an email to contact@purlinpress.com.
 '''
 
+[[photos]]
+id = "smnp"
+path = "1/smokeymountainsnationalpark"
+caption = "Smokey Mountain National Park"


### PR DESCRIPTION
I appear to get emails when builds fail lol

the definition in the toml file for the cover photo of id `smnp` wasn't defined which was crashing the webpack build, so I added back the placeholder definition to at least get it building. I know you'll have some awesome stuff to swap into its place later 🙂

Also side note, do you want to have a cover photo for every post? Otherwise I could look into modifying the post plugin